### PR TITLE
Fix webhook for woocommerce.

### DIFF
--- a/gateways/woo_satsale.php
+++ b/gateways/woo_satsale.php
@@ -126,7 +126,7 @@ function satsale_init_gateway_class() {
 
          	global $woocommerce;
 
-         	// we need it to get any order detailes
+         	// we need it to get any order details
          	$order = wc_get_order( $order_id );
 
             // We need to store a signature of the data, and check it later during the webhook to confirm it is the same!
@@ -135,7 +135,8 @@ function satsale_init_gateway_class() {
          	 */
          	$args = array(
                 'amount' => $order->get_total(),
-                'w_url' => $this->callback_URL );
+                'w_url' => $this->callback_URL,
+                'id' => $order_id)
 
             write_log($args);
 

--- a/gateways/woo_webhook.py
+++ b/gateways/woo_webhook.py
@@ -6,12 +6,12 @@ import time
 import requests
 
 
-def hook(satsale_secret, invoice):
+def hook(satsale_secret, invoice, order_id):
     key = codecs.decode(satsale_secret, "hex")
 
     # Calculate a secret that is required to send back to the
     # woocommerce gateway, proving we did not modify id nor amount.
-    secret_seed = str(int(100 * float(invoice["amount"]))).encode(
+    secret_seed = str(int(100 * float(invoice["dollar_value"]))).encode(
         "utf-8"
     )
     print("Secret seed: {}".format(secret_seed))
@@ -23,6 +23,7 @@ def hook(satsale_secret, invoice):
     params = {
         "wc-api": "wc_satsale_gateway",
         "time": str(paid_time),
+        "id": order_id
     }
     message = (str(paid_time) + "." + json.dumps(params, separators=(",", ":"))).encode(
         "utf-8"
@@ -37,6 +38,6 @@ def hook(satsale_secret, invoice):
     }
 
     # Send the webhook response, confirming the payment with woocommerce.
-    response = requests.get(invoice["w_url"], params=params, headers=headers)
+    response = requests.get(invoice["webhook"], params=params, headers=headers)
 
     return response


### PR DESCRIPTION
After recent upgrades, the id parameter (parameter sent from woocommerce, not payment uuid) was not being sent back with the webhook. This means payments would not successfully confirm in the store, despite having been paid.

This change also fixes the redirect after a successful payment.