### PR TITLE
rpc over tor hidden service for bitcoind

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,8 @@ api_key_path = "SatSale_API_key"
 # This forwards the ports required to talk to the node via RPC (or gRPC in the case of lightning)
 # Use host = "127.0.0.1" and you will be able to see your node on 8332
 tunnel_host = None  # "HOST@IP"
+# OR TOR HIDDEN SERVICE TO RPC
+tor_bitcoinrpc_host = None
 
 # Check for payment every xx seconds
 pollrate = 15

--- a/gateways/tor.py
+++ b/gateways/tor.py
@@ -1,0 +1,21 @@
+import socks
+import json
+import requests
+import time
+
+import config
+
+time.sleep(3)
+
+print("Using tor proxies {}:{}".format("localhost", 9050))
+session = requests.session()
+session.proxies = {
+    "http": "socks5h://localhost:9050",
+    "https": "socks5h://localhost:9050",
+}
+
+print(
+    "Checking tor circuit IP address... You should check this is different to your IP."
+)
+r = session.get("http://httpbin.org/ip")
+print(r.text)

--- a/pay/bitcoind.py
+++ b/pay/bitcoind.py
@@ -1,27 +1,60 @@
 import time
 import uuid
 import qrcode
+import json
 
 import config
+from gateways.tor import session
 from invoice.price_feed import get_btc_value
+
+
+def call_tor_bitcoin_rpc(method, params):
+    url = "{}:{}".format(config.tor_bitcoinrpc_host, config.rpcport)
+    payload = json.dumps({"method": method, "params": params})
+    headers = {"content-type": "application/json", "cache-control": "no-cache"}
+    response = session.request(
+        "POST",
+        url,
+        data=payload,
+        headers=headers,
+        auth=(config.username, config.password),
+    )
+    return json.loads(response.text)
 
 
 class btcd:
     def __init__(self):
         from bitcoinrpc.authproxy import AuthServiceProxy
 
-        connection_str = "http://{}:{}@{}:{}/wallet/{}".format(
-            config.username, config.password, config.host, config.rpcport, config.wallet
-        )
-        print("Attempting to connect to {}.".format(connection_str))
-
         for i in range(config.connection_attempts):
+            if config.tor_bitcoinrpc_host is None:
+                self.tor = False
+                connection_str = "http://{}:{}@{}:{}/wallet/{}".format(
+                    config.username,
+                    config.password,
+                    config.host,
+                    config.rpcport,
+                    config.wallet,
+                )
+                print("Attempting to connect to {}.".format(connection_str))
+            else:
+                self.tor = True
+                print(
+                    "Attempting to contact bitcoind rpc tor hidden service: {}:{}".format(
+                        config.tor_bitcoinrpc_host, config.rpcport
+                    )
+                )
+
             try:
-                self.rpc = AuthServiceProxy(connection_str)
+                # Normal Connection
+                if config.tor_bitcoinrpc_host is None:
+                    self.rpc = AuthServiceProxy(connection_str)
+                    info = self.rpc.getblockchaininfo()
+                # Tor Connection
+                else:
+                    info = call_tor_bitcoin_rpc("getblockchaininfo", None)
 
-                info = self.rpc.getblockchaininfo()
                 print(info)
-
                 print("Successfully contacted bitcoind.")
                 break
 
@@ -47,7 +80,11 @@ class btcd:
         return
 
     def check_payment(self, address):
-        transactions = self.rpc.listtransactions()
+        if not self.tor:
+            transactions = self.rpc.listtransactions()
+        else:
+            transactions = call_tor_bitcoin_rpc("listtransactions", None)["result"]
+
         relevant_txs = [tx for tx in transactions if tx["address"] == address]
 
         conf_paid = 0
@@ -63,8 +100,13 @@ class btcd:
     def get_address(self, amount, label):
         for i in range(config.connection_attempts):
             try:
-                address = self.rpc.getnewaddress(label)
+                if not self.tor:
+                    address = self.rpc.getnewaddress(label)
+                else:
+                    address = call_tor_bitcoin_rpc("getnewaddress", [label])["result"]
+
                 return address, None
+
             except Exception as e:
                 print(e)
                 print(

--- a/pay/bitcoind.py
+++ b/pay/bitcoind.py
@@ -4,8 +4,10 @@ import qrcode
 import json
 
 import config
-from gateways.tor import session
 from invoice.price_feed import get_btc_value
+
+if config.tor_bitcoinrpc_host is not None:
+    from gateways.tor import session
 
 
 def call_tor_bitcoin_rpc(method, params):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Pillow==8.01.1
 protobuf==3.15.6
 flask_restplus==0.13.0
 Werkzeug==0.16.1
-SocksiPy_branch==1.01
 
 
 # For lightning (optional)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Pillow==8.01.1
 protobuf==3.15.6
 flask_restplus==0.13.0
 Werkzeug==0.16.1
+SocksiPy_branch==1.01
 
 
 # For lightning (optional)


### PR DESCRIPTION
SatSale can now connect to your bitcoin node via a tor hidden service. 

Currently this requires
1. Adding a hidden service on your node in `/etc/tor/torrc`
2. Adding the hostname onion to `config.py` like `tor_bitcoinrpc_host = "http://u7...bid.onion"`
2. Running tor on your SatSale machine, with torrc (thanks @x_y:matrix.org):
```
SocksPort 127.0.0.1:9050 IsolateClientProtocol IsolateDestPort IsolateDestAddr ExtendedErrors IPv6Traffic PreferIPv6 KeepAliveIsolateSOCKSAuth
SocksPolicy accept 127.0.0.1
SocksPolicy reject *
```

Works as an alternative to ssh_tunnel, and probably has some small server side privacy benefits?

Will be looking at building the same for lightning network gRPC this week.