### PR TITLE
Filter bitcoind listtransactions by label

### DIFF
--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -81,17 +81,16 @@ class btcd:
         img.save("static/qr_codes/{}.png".format(uuid))
         return
 
-    def check_payment(self, address):
+    def check_payment(self, uuid):
         if not self.tor:
-            transactions = self.rpc.listtransactions()
+            transactions = self.rpc.listtransactions(uuid)
         else:
-            transactions = call_tor_bitcoin_rpc("listtransactions", None)["result"]
-
-        relevant_txs = [tx for tx in transactions if tx["address"] == address]
+            transactions = call_tor_bitcoin_rpc("listtransactions",
+                [uuid])["result"]
 
         conf_paid = 0
         unconf_paid = 0
-        for tx in relevant_txs:
+        for tx in transactions:
             if tx["confirmations"] >= config.required_confirmations:
                 conf_paid += tx["amount"]
             else:

--- a/satsale.py
+++ b/satsale.py
@@ -253,11 +253,9 @@ def check_payment_status(uuid):
         node = get_node(invoice["method"])
         if invoice["method"] == "lnd":
             conf_paid, unconf_paid = node.check_payment(invoice["rhash"])
-        elif invoice["method"] == "clightning":
-            # Lookup clightning invoice based on label (uuid)
-            conf_paid, unconf_paid = node.check_payment(invoice["uuid"])
         else:
-            conf_paid, unconf_paid = node.check_payment(invoice["address"])
+            # Lookup bitcoind / clightning invoice based on label (uuid)
+            conf_paid, unconf_paid = node.check_payment(invoice["uuid"])
 
         # Remove any Decimal types
         conf_paid, unconf_paid = float(conf_paid), float(unconf_paid)


### PR DESCRIPTION
See https://github.com/nickfarrow/SatSale/issues/26#issuecomment-998281760.

>  Better approach is to add UUID (label) as argument to `listtransactions` RPC, it has two benefits: 1) only incoming transactions will be returned, 2) less data to process in Python code. Your code already do it that way for c-lightning.

I was wrong in that comment about random order, it doesn't matter. If you send from the same Bitcoin Core wallet as receiving, amount will never match as both incoming and outgoing will be taken into account.