### PR TITLE
Fix onchain payment QR codes according to BIP21

### DIFF
--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -76,7 +76,7 @@ class btcd:
             )
 
     def create_qr(self, uuid, address, value):
-        qr_str = "{}?amount={}&label={}".format(address.upper(), value, uuid)
+        qr_str = "bitcoin:{}?amount={}&label={}".format(address, value, uuid)
 
         img = qrcode.make(qr_str)
         img.save("static/qr_codes/{}.png".format(uuid))


### PR DESCRIPTION
According to [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki), Bitcoin URIs start with `bitcoin:` scheme component. Also, there is no point in uppercasing address part here, as only benefit is smaller QR codes if string contains only uppercase letters, but that is not the case, as `amount=` and `label=` are required to be lowercase.

Also, existing code would not work properly if user has `legacy` or `psh-segwit` configured as `addresstype` in Bitcoin Core, as only bech32 addresses are case insensitive.