### PR TITLE
Fix BTC amount formatting for amounts below 0.0001

### DIFF
--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -7,6 +7,8 @@ import uuid
 
 import config
 from payments.price_feed import get_btc_value
+from utils import btc_amount_format
+
 
 if config.tor_bitcoinrpc_host is not None:
     from gateways.tor import session
@@ -92,7 +94,8 @@ class btcd:
             )
 
     def create_qr(self, uuid, address, value):
-        qr_str = "bitcoin:{}?amount={}&label={}".format(address, value, uuid)
+        qr_str = "bitcoin:{}?amount={}&label={}".format(
+            address, btc_amount_format(value), uuid)
 
         img = qrcode.make(qr_str)
         img.save("static/qr_codes/{}.png".format(uuid))

--- a/node/clightning.py
+++ b/node/clightning.py
@@ -60,7 +60,7 @@ class clightning:
     # Create lightning invoice
     def create_clightning_invoice(self, btc_amount, label):
         # Multiplying by 10^8 to convert to satoshi units
-        msats_amount = int(btc_amount * 10 ** (3 + 8))
+        msats_amount = int(float(btc_amount) * 10 ** (3 + 8))
         lnd_invoice = self.clightning.invoice(
             msats_amount, label, "SatSale-{}".format(label)
         )

--- a/node/lnd.py
+++ b/node/lnd.py
@@ -124,7 +124,7 @@ class lnd:
     # Create lightning invoice
     def create_lnd_invoice(self, btc_amount, memo=None, description_hash=None):
         # Multiplying by 10^8 to convert to satoshi units
-        sats_amount = int(btc_amount * 10 ** 8)
+        sats_amount = int(float(btc_amount) * 10 ** 8)
         res = self.lnd.add_invoice(
             value=sats_amount, memo=memo, description_hash=description_hash
         )

--- a/satsale.py
+++ b/satsale.py
@@ -24,6 +24,7 @@ from payments.price_feed import get_btc_value
 from node import bitcoind
 from node import lnd
 from node import clightning
+from utils import btc_amount_format
 
 from gateways import woo_webhook
 
@@ -146,7 +147,7 @@ class create_payment(Resource):
         invoice = {
             "uuid": str(uuid.uuid4().hex),
             "fiat_value": base_amount,
-            "btc_value": round(get_btc_value(base_amount, currency), 8),
+            "btc_value": btc_amount_format(get_btc_value(base_amount, currency)),
             "method": payment_method,
             "time": time.time(),
             "webhook": webhook,
@@ -277,20 +278,20 @@ def check_payment_status(uuid):
         dbg_free_mode_cond = config.free_mode and (time.time() - invoice["time"] > 5)
 
         # If payment is paid
-        if (conf_paid >= invoice["btc_value"]) or dbg_free_mode_cond:
+        if (conf_paid >= float(invoice["btc_value"])) or dbg_free_mode_cond:
             status.update(
                 {
                     "payment_complete": 1,
-                    "confirmed_paid": conf_paid,
-                    "unconfirmed_paid": unconf_paid,
+                    "confirmed_paid": btc_amount_format(conf_paid),
+                    "unconfirmed_paid": btc_amount_format(unconf_paid),
                 }
             )
         else:
             status.update(
                 {
                     "payment_complete": 0,
-                    "confirmed_paid": conf_paid,
-                    "unconfirmed_paid": unconf_paid,
+                    "confirmed_paid": btc_amount_format(conf_paid),
+                    "unconfirmed_paid": btc_amount_format(unconf_paid),
                 }
             )
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,4 @@
+
+def btc_amount_format(btc_amount):
+    return "%.8f" % float(btc_amount)
+


### PR DESCRIPTION
Floats less than 0.0001 in Python are converted to strings using scientific notation (`str(0.00000546)` is `5.46e-06` not `0.00000546`). Not only that looks ugly for average user, it also resulted in incorrect value of `amount` field in BIP21 `bitcoin:` URIs.

In a long term, correct way would be to use `Decimal` instead of `float` for monetary values, as float is approximation not exact value, other problems could arise.